### PR TITLE
Add tip calculator tool

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import UtilitariosFinanceiros from "./pages/UtilitariosFinanceiros";
 import BlogFinancas from "./pages/BlogFinancas";
 import AdsECursos from "./pages/AdsECursos";
 import NotFound from "./pages/NotFound";
+import CalculadoraGorjeta from "./pages/CalculadoraGorjeta";
 
 const queryClient = new QueryClient();
 
@@ -40,6 +41,7 @@ const AppWrapper = () => {
       <Route path="/utilitarios-financeiros" element={<UtilitariosFinanceiros />} />
       <Route path="/blog-financas" element={<BlogFinancas />} />
       <Route path="/ads-e-cursos" element={<AdsECursos />} />
+      <Route path="/calculadora-gorjeta" element={<CalculadoraGorjeta />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/src/pages/CalculadoraGorjeta.tsx
+++ b/src/pages/CalculadoraGorjeta.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import Layout from '../components/Layout';
+import { Coffee } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+
+const CalculadoraGorjeta = () => {
+  const [bill, setBill] = useState<number>(0);
+  const [tipPercent, setTipPercent] = useState<number>(10);
+  const [people, setPeople] = useState<number>(1);
+
+  const tipAmount = bill * (tipPercent / 100);
+  const total = bill + tipAmount;
+  const perPerson = people > 0 ? total / people : 0;
+
+  return (
+    <Layout>
+      <section className="bg-gradient-to-br from-amber-600 to-amber-800 text-white py-16">
+        <div className="container mx-auto px-4 text-center">
+          <Coffee className="h-16 w-16 mx-auto mb-6 text-amber-200" />
+          <h1 className="text-4xl font-bold mb-4">Calculadora de Gorjeta</h1>
+          <p className="text-xl text-amber-100">
+            Calcule facilmente a gorjeta e o valor por pessoa.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-12">
+        <div className="container mx-auto px-4 max-w-2xl">
+          <Card>
+            <CardHeader>
+              <CardTitle>Informe os valores</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <label className="text-sm font-medium">Valor da conta</label>
+                <Input
+                  type="number"
+                  value={bill}
+                  onChange={(e) => setBill(parseFloat(e.target.value) || 0)}
+                  placeholder="R$"
+                />
+              </div>
+              <div>
+                <label className="text-sm font-medium">Porcentagem da gorjeta (%)</label>
+                <Input
+                  type="number"
+                  value={tipPercent}
+                  onChange={(e) => setTipPercent(parseFloat(e.target.value) || 0)}
+                />
+              </div>
+              <div>
+                <label className="text-sm font-medium">Número de pessoas</label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={people}
+                  onChange={(e) => setPeople(parseInt(e.target.value) || 1)}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>Resultado</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <div className="flex justify-between">
+                <span>Gorjeta:</span>
+                <span>R$ {tipAmount.toFixed(2)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Total com gorjeta:</span>
+                <span>R$ {total.toFixed(2)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Valor por pessoa:</span>
+                <span>R$ {perPerson.toFixed(2)}</span>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    </Layout>
+  );
+};
+
+export default CalculadoraGorjeta;
+

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -43,6 +43,7 @@ const Index = () => {
     { path: '/empreendedorismo-local', label: 'Empreendedorismo', icon: <Briefcase className="h-5 w-5" />, color: 'from-purple-500 to-pink-500' },
     { path: '/investimentos', label: 'Investimentos', icon: <PiggyBank className="h-5 w-5" />, color: 'from-green-500 to-emerald-500' },
     { path: '/planejamento-aposentadoria', label: 'Cálculo de Aposentadoria', icon: <Calculator className="h-5 w-5" />, color: 'from-indigo-500 to-purple-500' },
+    { path: '/calculadora-gorjeta', label: 'Calculadora de Gorjeta', icon: <Coffee className="h-5 w-5" />, color: 'from-orange-500 to-amber-500' },
   ];
 
   const todasFerramentas = [
@@ -73,6 +74,13 @@ const Index = () => {
       icon: <Calculator className="h-6 w-6" />,
       path: '/calculadora-basica',
       color: 'from-gray-500 to-gray-600',
+    },
+    {
+      title: 'Calculadora de Gorjeta',
+      description: 'Calcule gorjetas e divida o valor por pessoa',
+      icon: <Coffee className="h-6 w-6" />,
+      path: '/calculadora-gorjeta',
+      color: 'from-orange-500 to-amber-600',
     },
   ];
 

--- a/src/pages/UtilitariosFinanceiros.tsx
+++ b/src/pages/UtilitariosFinanceiros.tsx
@@ -7,7 +7,7 @@ import NewsletterSubscription from '../components/NewsletterSubscription';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Link } from 'react-router-dom';
-import { Calculator, PiggyBank, TrendingUp, Users, Beer, GraduationCap, Car, DollarSign } from 'lucide-react';
+import { Calculator, PiggyBank, TrendingUp, Users, Beer, GraduationCap, Car, DollarSign, Coffee } from 'lucide-react';
 
 const UtilitariosFinanceiros = () => {
   const ferramentas = [
@@ -74,6 +74,14 @@ const UtilitariosFinanceiros = () => {
       icon: Beer,
       cor: 'bg-amber-50 text-amber-600 border-amber-200',
       categoria: 'Diversão'
+    },
+    {
+      titulo: 'Calculadora de Gorjeta',
+      descricao: 'Calcule a gorjeta e o total por pessoa',
+      link: '/calculadora-gorjeta',
+      icon: Coffee,
+      cor: 'bg-orange-50 text-orange-600 border-orange-200',
+      categoria: 'Utilidade'
     },
     {
       titulo: 'Calculadora Básica',


### PR DESCRIPTION
## Summary
- add calculator for tips with bill, percentage, and split per person
- link tip calculator from quick menu and utilities page
- register new route for tip calculator

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any in existing files)
- `npx eslint src/App.tsx src/pages/Index.tsx src/pages/UtilitariosFinanceiros.tsx src/pages/CalculadoraGorjeta.tsx`
- `npm run build` (incomplete, process ended after module transform)


------
https://chatgpt.com/codex/tasks/task_e_689bcf761ef88330a3e8e03a0d264adb